### PR TITLE
Add placeholder battle sprites for battle participants

### DIFF
--- a/Assets/Scenes/BattlePrototype.unity
+++ b/Assets/Scenes/BattlePrototype.unity
@@ -317,6 +317,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2100000001}
   - {fileID: 788566373}
   m_Father: {fileID: 178908882}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -335,9 +336,84 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6758b745722d14280a9c522e172c2c7d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   attackCircle: {fileID: 788566374}
+--- !u!1 &2100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000001}
+  - component: {fileID: 2100000003}
+  - component: {fileID: 2100000002}
+  m_Layer: 5
+  m_Name: PlayerSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2100000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 66838822}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 360, y: 360}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2100000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2100000003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_CullTransparentMesh: 1
 --- !u!1 &141717658
 GameObject:
   m_ObjectHideFlags: 0
@@ -511,6 +587,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2100000011}
   - {fileID: 66838822}
   - {fileID: 884307999}
   - {fileID: 733975496}
@@ -524,6 +601,81 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &2100000010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000011}
+  - component: {fileID: 2100000013}
+  - component: {fileID: 2100000012}
+  m_Layer: 5
+  m_Name: EnemySprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2100000011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000010}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 178908882}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 500, y: 0}
+  m_SizeDelta: {x: 360, y: 360}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2100000012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2100000013
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000010}
+  m_CullTransparentMesh: 1
 --- !u!1 &259224900
 GameObject:
   m_ObjectHideFlags: 0
@@ -971,10 +1123,12 @@ MonoBehaviour:
   playerHPBar: {fileID: 62089245}
   playerHPText: {fileID: 2035457856}
   playerManaText: {fileID: 1160500551}
+  playerSpriteImage: {fileID: 2100000002}
   enemyNameText: {fileID: 1936276487}
   enemyHPBar: {fileID: 871954421}
   enemyHPText: {fileID: 14144906}
   enemyManaText: {fileID: 1180619713}
+  enemySpriteImage: {fileID: 2100000012}
   move1Btn: {fileID: 1541128386}
   move2Btn: {fileID: 1307620464}
   move3Btn: {fileID: 1390141957}

--- a/Assets/Scriptables/Monsters/Embercub.asset
+++ b/Assets/Scriptables/Monsters/Embercub.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   LUK: 3
   maxHP: 100
   startMana: 1
+  battleSprite: {fileID: 0}
   moves:
   - {fileID: 11400000, guid: 65a4a570f0dd346d2b8e5e537dba68b1, type: 2}
   - {fileID: 11400000, guid: 1413c60a9d5e140b386ec8f7118a207c, type: 2}

--- a/Assets/Scriptables/Monsters/Sprigun.asset
+++ b/Assets/Scriptables/Monsters/Sprigun.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   LUK: 2
   maxHP: 110
   startMana: 1
+  battleSprite: {fileID: 0}
   moves:
   - {fileID: 11400000, guid: 815d6d8b1ce0e49f0a734a9e7de955cd, type: 2}
   - {fileID: 11400000, guid: 6e93ac1934d2a4d6da94172dad62f5f0, type: 2}

--- a/Assets/Scripts/Battle/BattleManager.cs
+++ b/Assets/Scripts/Battle/BattleManager.cs
@@ -16,11 +16,13 @@ public class BattleManager : MonoBehaviour
     public Slider playerHPBar;
     public Text playerHPText;
     public Text playerManaText;
+    public Image playerSpriteImage;
 
     public Text enemyNameText;
     public Slider enemyHPBar;
     public Text enemyHPText;
     public Text enemyManaText;
+    public Image enemySpriteImage;
 
     public Button move1Btn, move2Btn, move3Btn;
     public QTEController qte;
@@ -40,6 +42,9 @@ public class BattleManager : MonoBehaviour
         retryButton.gameObject.SetActive(false);
         P = new MonsterRuntime(playerMonsterSO);
         E = new MonsterRuntime(enemyMonsterSO);
+
+        ApplyBattleSprite(playerSpriteImage, P.data.battleSprite);
+        ApplyBattleSprite(enemySpriteImage, E.data.battleSprite);
 
         playerNameText.text = P.data.displayName;
         enemyNameText.text = E.data.displayName;
@@ -372,5 +377,12 @@ public class BattleManager : MonoBehaviour
     {
         if (logText) logText.text = s;
         Debug.Log(s);
+    }
+
+    void ApplyBattleSprite(Image target, Sprite sprite)
+    {
+        if (!target) return;
+        target.sprite = sprite;
+        target.enabled = sprite != null;
     }
 }

--- a/Assets/Scripts/Data/MonsterSO.cs
+++ b/Assets/Scripts/Data/MonsterSO.cs
@@ -19,4 +19,7 @@ public class MonsterSO : ScriptableObject
     public int startMana = 1;
 
     public MoveSO[] moves = new MoveSO[3];
+
+    [Header("Visuals")]
+    public Sprite battleSprite;
 }


### PR DESCRIPTION
## Summary
- add battle sprite support to the monster data and battle manager UI wiring
- place player and enemy sprite images in the battle prototype scene for future animations

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68de3459bb7883259528f0135bd80d46